### PR TITLE
modify user DB and form

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -46,7 +46,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :kana_name, :sex, :birthday, :phone_number, :introduction, :image, :person])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :kana_name, :sex, :birthday, :phone_number, :postal_code, :prefecture, :city, :street, :building, :introduction, :image, :person])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :kana_name, :sex, :birthday, :phone_number, :email, :introduction, :image)
+    params.require(:user).permit(:name, :kana_name, :sex, :birthday, :phone_number, :prefecture, :city, :street, :building, :email, :introduction, :image)
   end
 
   def set_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,27 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   enum sex:{men: 0, women: 1, others: 2}
+  enum prefecture: {
+    北海道:1,
+    青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,
+    沖縄県:47
+  }
 
   validates :name, presence: true, length:{maximum: 20}
   validates :kana_name, presence: true
   validates :sex, presence: true
   validates :phone_number, presence: true
+
+
+  def address
+    self.prefecture + self.city + self.street + self.building
+  end
+
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,12 +21,12 @@
 
             <div class="field">
               <%= f.label :name, "氏名" %>
-              <%= f.text_field :name, autofocus: true, autocomplete: "name", class:"form-control" %>
+              <%= f.text_field :name, autofocus: true, autocomplete: "name", class:"form-control", placeholder: "例:山田　太郎" %>
             </div>
 
             <div class="field">
               <%= f.label :kana_name, "カナ氏名" %><br />
-              <%= f.text_field :kana_name, autofocus: true, autocomplete: "kana_name", class:"form-control" %>
+              <%= f.text_field :kana_name, autofocus: true, autocomplete: "kana_name", class:"form-control", placeholder: "例:ヤマダ　タロウ" %>
             </div>
 
             <div class="field">
@@ -51,8 +51,33 @@
             </div>
 
             <div class="field">
+              <%= f.label :postal_code, "郵便番号（ハイフンなし）" %><br />
+              <%= f.number_field :postal_code, autofocus: true, autocomplete: "postal_code", class:"form-control", placeholder: "例:1610001" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :prefecture, "都道府県" %><br>
+              <%= f.select :prefecture, User.prefectures.keys, {prompt: '選択してください'}, class: 'form-control' %>
+            </div>
+
+            <div class="field">
+              <%= f.label :city, "市区町村" %><br />
+              <%= f.text_field :city, autofocus: true, autocomplete: "city", class:"form-control", placeholder: "例:新宿区三丁目" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :street, "番地" %><br />
+              <%= f.text_field :street, autofocus: true, autocomplete: "street", class:"form-control", placeholder: "例:1-20" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :building, "マンション名等" %><br />
+              <%= f.text_field :building, autofocus: true, autocomplete: "building", class:"form-control", placeholder: "例:メゾン　３０２号室" %>
+            </div>
+
+            <div class="field">
               <%= f.label :phone_number, "電話番号（ハイフンなし）" %><br />
-              <%= f.number_field :phone_number, autofocus: true, autocomplete: "phone_number", class:"form-control" %>
+              <%= f.number_field :phone_number, autofocus: true, autocomplete: "phone_number", class:"form-control", placeholder: "例:08012345678" %>
             </div>
 
             <div class="field">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,6 +23,31 @@
         </div>
 
         <div class="field">
+              <%= f.label :postal_code, "郵便番号（ハイフンなし）" %><br />
+              <%= f.number_field :postal_code, autofocus: true, autocomplete: "postal_code", class:"form-control", placeholder: "例:1610001" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :prefecture, "都道府県" %><br>
+              <%= f.select :prefecture, User.prefectures.keys, {prompt: '選択してください'}, class: 'form-control' %>
+            </div>
+
+            <div class="field">
+              <%= f.label :city, "市区町村" %><br />
+              <%= f.text_field :city, autofocus: true, autocomplete: "city", class:"form-control", placeholder: "例:新宿区三丁目" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :street, "番地" %><br />
+              <%= f.text_field :street, autofocus: true, autocomplete: "street", class:"form-control", placeholder: "例:1-20" %>
+            </div>
+
+            <div class="field">
+              <%= f.label :building, "マンション名等" %><br />
+              <%= f.text_field :building, autofocus: true, autocomplete: "building", class:"form-control", placeholder: "例:メゾン　３０２号室" %>
+            </div>
+
+        <div class="field">
           <%= f.label :email, "メールアドレス" %><br />
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control" %>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,6 +21,12 @@
             <div class="birthday">
               <p>生年月日：<%= @user.birthday.strftime("%Y年%m月%d日") %></p>
             </div>
+            <div class="address">
+              <p>
+                〒<%= @user.postal_code %><br>
+                <%= @user.address %>
+              </p>
+            </div>
             <div class="phone_number">
               <p>電話番号：<%= @user.phone_number %></p>
             </div>

--- a/db/migrate/20200614111243_devise_create_users.rb
+++ b/db/migrate/20200614111243_devise_create_users.rb
@@ -34,9 +34,14 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
 
       t.string :name, null: false
       t.string :kana_name, null: false
-      t.integer :sex
-      t.date :birthday
-      t.string :phone_number
+      t.integer :sex, null: false
+      t.date :birthday, null: false
+      t.string :phone_number, null: false
+      t.string :postal_code, null: false
+      t.integer :prefecture, null: false
+      t.string :city, null: false
+      t.string :street, null: false
+      t.string :building
       t.text :introduction
       t.string :image
       t.boolean :person

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,9 +27,14 @@ ActiveRecord::Schema.define(version: 2020_06_14_111243) do
     t.datetime "locked_at"
     t.string "name", null: false
     t.string "kana_name", null: false
-    t.integer "sex"
-    t.date "birthday"
-    t.string "phone_number"
+    t.integer "sex", null: false
+    t.date "birthday", null: false
+    t.string "phone_number", null: false
+    t.string "postal_code", null: false
+    t.integer "prefecture", null: false
+    t.string "city", null: false
+    t.string "street", null: false
+    t.string "building"
     t.text "introduction"
     t.string "image"
     t.boolean "person"


### PR DESCRIPTION
別テーブルで定義する予定だったユーザーの住所は、案件とは関係なく履歴書に反映させるものであり、１：１の関係であるためUserモデルの中に埋め込む形にした。
それに伴って、フォームを編集し、必要事項を入力してもらう形となった。